### PR TITLE
chore: remove php version limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4 <8.4",
+        "php": ">=7.4",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "ext-simplexml": "*",


### PR DESCRIPTION
Is there a reason why PHP version cannot be higher than 8.4?
If not, I propose this PR to remove the limitation.

Thanks!